### PR TITLE
remove rad dudecast

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -132,22 +132,7 @@
       </section>
       <!-- End History Section -->
 
-      <!-- Podcast Section -->
-      <!-- <section id="podcast" class="section&#45;padding"> -->
-      <section id="podcast" class="center">
-        <!-- <div class="container text&#45;center ptb&#45;90 col&#45;md&#45;12"> -->
-        <div class="container text-center mb-60 col-md-12">
-          <h1>The Rad Dudecast</h1>
-          <a href="https://www.patreon.com/raddudecast">
-            <img src="/img/TRDC.jpg" style="max-width: 340px; width 100%;" alt="" />
-          </a></br></br></br>
-          <p class="lead-lg max-width-700">The Rad Dudecast is an
-          irreverent mix of stupidity and genius hosted by Anthony Devito,
-          Greg Stone, and Brendan Eyre. Its part improv, part discussion,
-          and part pure sex. Its extraordinarily popular. We think. None
-          of us have looked at the numbers.</p>
-        </div>
-      </section>
+
 
       <!-- Contact Infobar Section -->
       <section class="ptb-60 black-bg text-center dark-bg">


### PR DESCRIPTION
### **User description**
This pull request removes the entire Podcast section from the `index.html.erb` static page. The section previously featured information and a link to "The Rad Dudecast" podcast.

Content removal:

* Deleted the entire Podcast section, including its header, description, image, and Patreon link, from `app/views/static_pages/index.html.erb`.


___

### **PR Type**
Other


___

### **Description**
- Remove entire Podcast section from homepage

- Delete "The Rad Dudecast" content and Patreon link


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Homepage with Podcast"] --> B["Homepage without Podcast"]
  A -- "Remove section" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Content removal</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html.erb</strong><dd><code>Remove podcast section from homepage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/static_pages/index.html.erb

<ul><li>Remove complete Podcast section containing "The Rad Dudecast"<br> <li> Delete section header, description, image, and Patreon link<br> <li> Clean up HTML structure after content removal</ul>


</details>


  </td>
  <td><a href="https://github.com/BGRicker/brendan-eyre/pull/56/files#diff-6fbbdc20d8dca32618e9da61910e0944c71a852662adaeb66108e0aad8940808">+1/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

